### PR TITLE
[FE] 베팅 관리자 페이지 리팩토링

### DIFF
--- a/frontend/src/features/betting-page-admin/index.tsx
+++ b/frontend/src/features/betting-page-admin/index.tsx
@@ -164,8 +164,8 @@ function BettingPageAdmin() {
 
   const handleCancelClick = async () => {
     refund(roomId)
-      .then((data) => {
-        console.log("API 성공 결과:", data);
+      .then(() => {
+        sessionStorage.removeItem("userInfo");
         navigate({
           to: "/my-page",
         });

--- a/frontend/src/features/betting-page-admin/index.tsx
+++ b/frontend/src/features/betting-page-admin/index.tsx
@@ -1,5 +1,9 @@
 import { BettingStatsDisplay } from "@/shared/components/BettingStatsDisplay/BettingStatsDisplay";
-import { useNavigate, useParams, useRouter } from "@tanstack/react-router";
+import {
+  useNavigate,
+  useRouteContext,
+  useRouter,
+} from "@tanstack/react-router";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useSocketIO } from "@/shared/hooks/useSocketIo";
 import { BettingTimer } from "@/shared/components/BettingTimer/BettingTimer";
@@ -9,23 +13,17 @@ import { endBetRoom, refund } from "./model/api";
 import { useLayoutShift } from "@/shared/hooks/useLayoutShift";
 import { bettingRoomSchema } from "../betting-page/model/schema";
 import { DuckCoinIcon } from "@/shared/icons";
-import { useSuspenseQuery } from "@tanstack/react-query";
-import { bettingRoomQueryKey } from "@/shared/lib/bettingRoomInfo";
-import { getBettingRoomInfo } from "../betting-page/api/getBettingRoomInfo";
 import { responseBetRoomInfo } from "@betting-duck/shared";
 
 function BettingPageAdmin() {
   useLayoutShift();
-  const router = useRouter();
-  const { roomId } = useParams({
-    from: "/betting_/$roomId/vote",
-  });
 
-  const { data } = useSuspenseQuery({
-    queryKey: bettingRoomQueryKey(roomId),
-    queryFn: () => getBettingRoomInfo(roomId),
-  });
-  const parsedData = responseBetRoomInfo.safeParse(data);
+  const context = useRouteContext({ from: "/betting_/$roomId/vote/admin" });
+  const roomInfo = context.roomInfo;
+
+  const router = useRouter();
+
+  const parsedData = responseBetRoomInfo.safeParse(roomInfo);
   if (!parsedData.success) {
     throw new Error("방 정보를 불러오는데 실패했습니다.");
   }
@@ -44,6 +42,7 @@ function BettingPageAdmin() {
   >(null);
 
   // Room Information
+  const roomId = channel.id;
   const option1 = channel.options.option1;
   const option2 = channel.options.option2;
   const defaultBetAmount = channel.settings.defaultBetAmount;

--- a/frontend/src/features/betting-page-admin/index.tsx
+++ b/frontend/src/features/betting-page-admin/index.tsx
@@ -13,6 +13,7 @@ import { endBetRoom, refund } from "./model/api";
 import { useLayoutShift } from "@/shared/hooks/useLayoutShift";
 import { bettingRoomSchema } from "../betting-page/model/schema";
 import { DuckCoinIcon } from "@/shared/icons";
+import BettingDetails from "./ui/BettingDetails";
 
 function BettingPageAdmin() {
   useLayoutShift();
@@ -36,11 +37,12 @@ function BettingPageAdmin() {
   >(null);
 
   // Room Information
-  const roomId = channel.id;
-  const option1 = channel.options.option1;
-  const option2 = channel.options.option2;
-  const defaultBetAmount = channel.settings.defaultBetAmount;
-  const timer = channel.settings.duration;
+  const {
+    id: roomId,
+    title,
+    options: { option1, option2 },
+    settings: { defaultBetAmount, duration: timer },
+  } = channel;
 
   const socket = useSocketIO({
     url: "/api/betting",
@@ -202,10 +204,6 @@ function BettingPageAdmin() {
     }
   };
 
-  const getTotalParticipants = () => {
-    return bettingInfo.option1.participants + bettingInfo.option2.participants;
-  };
-
   const getTotalBetAmount = () => {
     return bettingInfo.option1.currentBets + bettingInfo.option2.currentBets;
   };
@@ -270,35 +268,12 @@ function BettingPageAdmin() {
       <div className="flex flex-col gap-5">
         <BettingTimer socket={socket} bettingRoomInfo={roomInfo} />
         <div className="flex flex-col gap-6 p-5">
-          <div className="bg-secondary mb-4 rounded-lg p-3 text-center shadow-inner">
-            <h1 className="text-default-disabled text-md mb-1 font-bold">
-              베팅 주제
-            </h1>
-            <h1 className="text-primary mb-1 pt-2 text-4xl font-extrabold">
-              {channel.title}
-            </h1>
-            <p>
-              {status === "active"
-                ? "투표가 진행 중입니다. 투표를 취소할 수 있습니다."
-                : "투표가 종료되었습니다. 승부를 결정하세요!"}
-            </p>
-            <h1 className="text-default-disabled text-md mb-1 font-bold">
-              베팅 정보
-            </h1>
-            <p>
-              ∙ 최소 베팅 금액:{" "}
-              <span className="font-extrabold">{defaultBetAmount}</span>
-            </p>
-            <p>
-              ∙ 설정한 시간:{" "}
-              <span className="font-extrabold">{timer / 60}분</span>
-            </p>
-            <p>
-              ∙ 전체 베팅 참여자:{" "}
-              <span className="font-extrabold">{getTotalParticipants()}</span>
-            </p>
-          </div>
-
+          <BettingDetails
+            title={title}
+            defaultBetAmount={defaultBetAmount}
+            timer={timer}
+            status={status}
+          />
           {status === "timeover" ? (
             <div className="flex w-full overflow-hidden rounded-xl border">
               <div className="relative flex w-1/2">

--- a/frontend/src/features/betting-page-admin/index.tsx
+++ b/frontend/src/features/betting-page-admin/index.tsx
@@ -13,21 +13,15 @@ import { endBetRoom, refund } from "./model/api";
 import { useLayoutShift } from "@/shared/hooks/useLayoutShift";
 import { bettingRoomSchema } from "../betting-page/model/schema";
 import { DuckCoinIcon } from "@/shared/icons";
-import { responseBetRoomInfo } from "@betting-duck/shared";
 
 function BettingPageAdmin() {
   useLayoutShift();
 
   const context = useRouteContext({ from: "/betting_/$roomId/vote/admin" });
   const roomInfo = context.roomInfo;
+  const channel = roomInfo.channel;
 
   const router = useRouter();
-
-  const parsedData = responseBetRoomInfo.safeParse(roomInfo);
-  if (!parsedData.success) {
-    throw new Error("방 정보를 불러오는데 실패했습니다.");
-  }
-  const { channel } = parsedData.data;
 
   const [status, setStatus] = useState(channel.status || "active");
   const [bettingInfo, setBettingInfo] = useState({
@@ -274,7 +268,7 @@ function BettingPageAdmin() {
   return (
     <div className="bg-layout-main flex h-full w-full flex-col justify-between">
       <div className="flex flex-col gap-5">
-        <BettingTimer socket={socket} bettingRoomInfo={parsedData.data} />
+        <BettingTimer socket={socket} bettingRoomInfo={roomInfo} />
         <div className="flex flex-col gap-6 p-5">
           <div className="bg-secondary mb-4 rounded-lg p-3 text-center shadow-inner">
             <h1 className="text-default-disabled text-md mb-1 font-bold">

--- a/frontend/src/features/betting-page-admin/ui/BettingDetails.tsx
+++ b/frontend/src/features/betting-page-admin/ui/BettingDetails.tsx
@@ -1,0 +1,39 @@
+function BettingDetails({
+  title,
+  defaultBetAmount,
+  timer,
+  status,
+}: {
+  title: string;
+  defaultBetAmount: number;
+  timer: number;
+  status: string;
+}) {
+  return (
+    <div className="bg-secondary mb-4 rounded-lg p-3 text-center shadow-inner">
+      <h1 className="text-default-disabled text-md mb-1 font-bold">
+        베팅 주제
+      </h1>
+      <h1 className="text-primary mb-1 pt-2 text-4xl font-extrabold">
+        {title}
+      </h1>
+      <p>
+        {status === "active"
+          ? "투표가 진행 중입니다. 투표를 취소할 수 있습니다."
+          : "투표가 종료되었습니다. 승부를 결정하세요!"}
+      </p>
+      <h1 className="text-default-disabled text-md mb-1 font-bold">
+        베팅 정보
+      </h1>
+      <p>
+        ∙ 최소 베팅 금액:{" "}
+        <span className="font-extrabold">{defaultBetAmount}</span>
+      </p>
+      <p>
+        ∙ 설정한 시간: <span className="font-extrabold">{timer / 60}분</span>
+      </p>
+    </div>
+  );
+}
+
+export default BettingDetails;

--- a/frontend/src/routes/betting_.$roomId.vote.admin.tsx
+++ b/frontend/src/routes/betting_.$roomId.vote.admin.tsx
@@ -18,7 +18,7 @@ export const Route = createFileRoute("/betting_/$roomId/vote/admin")({
     return { roomInfo };
   },
 
-  shouldReload: () => true,
+  shouldReload: () => false,
   errorComponent: ({ error }) => {
     return <GlobalErrorComponent error={error} to="/" />;
   },


### PR DESCRIPTION
## 🔍 이슈
#2 

## 📗 작업 내역
- Tanstack Router의 `beforeLoad`, `useRouteContext`를 활용한 베팅 관리자 페이지의 bettingRoomInfo API 캐싱
- 기존에 bettingRoomInfo API 응답값을 라우터와 컴포넌트 모두에서 중복 검증하고 있던 것을 라우터에서만 검증하도록 수정
- 베팅 상세 정보 부분 컴포넌트로 분리
- 베팅 관리자 페이지에서 베팅 취소 시 세션 스토리지값을 삭제하도록 구현: 기존에 베팅을 취소해도 세션 스토리지값이 삭제되지 않아 계속 베팅에 참여중이라 인식하는 문제가 있었음. 해당 문제 해결

## 📋 PR 유형

- [ ] 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않은 변경 사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 파일 혹은 폴더 추가

## ⚠️ 추가적으로 설명할 내용
세션 스토리지 값을 삭제하도록 한 것은 임시 조치고, 세션 스토리지를 사용하는 방식에서 **쿠키를 사용하는 방식으로 전환**이 필요합니다.
